### PR TITLE
feat: delete key after use

### DIFF
--- a/src/translator/base.ts
+++ b/src/translator/base.ts
@@ -168,6 +168,7 @@ export abstract class BaseTranslator extends TranslatorAdapter {
     if (this.interpolationReplaceMap.has(key)) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const arr = this.interpolationReplaceMap.get(key)!;
+      this.interpolationReplaceMap.delete(key);
       return str.replace(this.reductionReg, (_, i) => arr[i]);
     } else {
       return str;

--- a/src/translator/base.ts
+++ b/src/translator/base.ts
@@ -94,11 +94,15 @@ export abstract class BaseTranslator extends TranslatorAdapter {
 
   abstract get name(): string;
 
+  getKey(key: string, target: string) {
+    return `__${target}__${key}__`
+  }
+
   translate(record: Record<string, string>, target: string, sourceLanguage: string): Observable<TranslatedList> {
     return from(Object.entries(record)).pipe(
       filter(([_, value]) => !!value),
       map(([key, value]) => {
-        const str = this.replaceInterpolation(key, value);
+        const str = this.replaceInterpolation(this.getKey(key, target), value);
         return [key, str];
       }),
 
@@ -139,7 +143,7 @@ export abstract class BaseTranslator extends TranslatorAdapter {
           map(list =>
             list.map((text, i) => {
               const key = keys[i];
-              return { target, translatedText: this.reductionInterpolation(key, text), key };
+              return { target, translatedText: this.reductionInterpolation(this.getKey(key, target), text), key };
             })
           )
         );


### PR DESCRIPTION
使用完map后应该删掉对应的存储，我这边的使用场景是用index做key，所以两轮翻译中会有相同的index，比如第一轮翻译记录了 { test } 映射成 $$1，而下一轮翻译中刚好存在$$1这个文案，将会被直接反向还原成{ test } ，这是不符合预期的